### PR TITLE
feat(curriculum): add form 3 algebra and fix assessment validation

### DIFF
--- a/curricula/malaysia/kssm/matematik-tingkatan1/topics/algebra/05-ungkapan-algebra.assessments.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan1/topics/algebra/05-ungkapan-algebra.assessments.yaml
@@ -303,7 +303,11 @@ questions:
         criteria: "Correctly states xz / 2 or equivalent."
     hints:
       - level: 1
-        text: "MISCONCEPTION ALERT: The coefficient is not strictly just the number in front. Use the 'cover-up' method: cover the given coefficient part (3xy) in the main term, and whatever is left over is the variable part."
+        text: >-
+          MISCONCEPTION ALERT: The coefficient is not strictly just the number
+          in front. Use the 'cover-up' method: cover the given coefficient part
+          (3xy) in the main term, and whatever is left over is the variable
+          part.
       - level: 2
         text: "The term is $3 \\times x \\times x \\times y \\times z / 2$."
       - level: 3

--- a/curricula/malaysia/kssm/matematik-tingkatan1/topics/algebra/06-persamaan-linear.assessments.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan1/topics/algebra/06-persamaan-linear.assessments.yaml
@@ -425,7 +425,14 @@ questions:
   # EXAM: UASA (Bahagian A - OAP)
   # RATIONALE: Encourages 'Kaedah Cuba Jaya' (Trial and Improvement) or mapping simultaneous logic from MCQ options.
   - id: Q17
-    text: "Nina bought 5 notebooks and 4 pens for RM14. Which of the following is the price of a book and a pen?\n\nA) Book: RM2.00, Pen: RM1.00\nB) Book: RM1.50, Pen: RM1.60\nC) Book: RM2.00, Pen: RM1.60\nD) Book: RM1.50, Pen: RM1.00"
+    text: >-
+      Nina bought 5 notebooks and 4 pens for RM14. Which of the following is
+      the price of a book and a pen?
+
+      A) Book: RM2.00, Pen: RM1.00
+      B) Book: RM1.50, Pen: RM1.60
+      C) Book: RM2.00, Pen: RM1.60
+      D) Book: RM1.50, Pen: RM1.00
     difficulty: medium
     learning_objective: 6.2.3
     answer:
@@ -499,7 +506,11 @@ questions:
   # EXAM: UASA (Bahagian C - Subjektif)
   # RATIONALE: Classic age-related word problem testing algebraic translation and basic linear solving.
   - id: Q20
-    text: "(i) Sufian is 5 years younger than his elder sister. If Sufian's age is $x$ years old, express the age of Sufian's elder sister in terms of $x$.\n(ii) Sufian is 2 years older than his younger brother. If his younger brother is 4 years old, find the age of Sufian's sister."
+    text: >-
+      (i) Sufian is 5 years younger than his elder sister. If Sufian's age is
+      $x$ years old, express the age of Sufian's elder sister in terms of $x$.
+      (ii) Sufian is 2 years older than his younger brother. If his younger
+      brother is 4 years old, find the age of Sufian's sister.
     difficulty: medium
     learning_objective: 6.1.2
     answer:
@@ -528,7 +539,10 @@ questions:
   # EXAM: UASA (Bahagian C - Subjektif)
   # RATIONALE: A complex TP5 multi-step problem that links expressions built in a previous question to form and solve simultaneous equations using substitution.
   - id: Q21
-    text: "Given that Adam's crops sold for $1500x + 700y$ and Hani's crops sold for $800x + 1600y$:\nIf $x = 5$ and the total amount of money received by Adam is RM9 600, calculate the total amount of cash received by Hani."
+    text: >-
+      Given that Adam's crops sold for $1500x + 700y$ and Hani's crops sold for
+      $800x + 1600y$: If $x = 5$ and the total amount of money received by Adam
+      is RM9 600, calculate the total amount of cash received by Hani.
     difficulty: hard
     learning_objective: 6.3.3
     answer:
@@ -542,7 +556,7 @@ questions:
         700y = 9600 - 7500
         700y = 2100
         y = 3
-        
+
         Hani's expression = 800x + 1600y
         Substitute x = 5 and y = 3:
         Hani's total = 800(5) + 1600(3)

--- a/curricula/malaysia/kssm/matematik-tingkatan1/topics/algebra/07-ketaksamaan-linear.assessments.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan1/topics/algebra/07-ketaksamaan-linear.assessments.yaml
@@ -253,7 +253,14 @@ questions:
   # EXAM: UASA (Bahagian A - OAP)
   # RATIONALE: Tests basic arithmetic property generalizations on inequalities.
   - id: Q12
-    text: "Form a new inequality by performing the operation stated in the brackets.\n$\\frac{3}{4}g > -6 \\quad [\\times \\frac{2}{3}]$\n\nA) $\\frac{g}{3} > -6$\nB) $\\frac{g}{2} > -4$\nC) $\\frac{g}{2} < -4$\nD) $\\frac{g}{3} > -6$"
+    text: >-
+      Form a new inequality by performing the operation stated in the brackets.
+      $\\frac{3}{4}g > -6 \\quad [\\times \\frac{2}{3}]$
+
+      A) $\\frac{g}{3} > -6$
+      B) $\\frac{g}{2} > -4$
+      C) $\\frac{g}{2} < -4$
+      D) $\\frac{g}{3} > -6$
     difficulty: medium
     learning_objective: 7.1.2
     answer:
@@ -281,7 +288,15 @@ questions:
   # EXAM: UASA (Bahagian A - OAP)
   # RATIONALE: A cross-topic synthesis linking inequality ranges to set theory universal domains and complements.
   - id: Q13
-    text: "Given universal set: $\\{x : x < 15, x \\text{ is an even number}\\}$\nSet P = {multiples of 3}\nFind $P'$.\n\nA) {3, 6, 9, 12}\nB) {2, 4, 6, 8, 10, 12, 14}\nC) {1, 3, 5, 7, 9, 11, 13}\nD) {2, 4, 8, 10, 14}"
+    text: >-
+      Given universal set: $\\{x : x < 15, x \\text{ is an even number}\\}$
+      Set P = {multiples of 3}
+      Find $P'$.
+
+      A) {3, 6, 9, 12}
+      B) {2, 4, 6, 8, 10, 12, 14}
+      C) {1, 3, 5, 7, 9, 11, 13}
+      D) {2, 4, 8, 10, 14}
     difficulty: hard
     learning_objective: 7.2.2
     answer:
@@ -309,7 +324,14 @@ questions:
   # EXAM: UASA (Bahagian C - Subjektif)
   # RATIONALE: Tests the critical difference between strict (<) and inclusive (<=) inequalities when mapped to integer lists.
   - id: Q14
-    text: "Match the given integer solution sets to their correct inequality range. Ranges available: $[1 < x < 3], [1 \\leq x < 3], [-1 \\leq x \\leq 3], [-1 < x < 3]$\n\n(i) $x = -1, 0, 1, 2, 3$ corresponds to which range?\n(ii) $x = 1, 2$ corresponds to which range?\n(iii) $x = 0, 1, 2$ corresponds to which range?"
+    text: >-
+      Match the given integer solution sets to their correct inequality range.
+      Ranges available: $[1 < x < 3], [1 \\leq x < 3], [-1 \\leq x \\leq 3],
+      [-1 < x < 3]$
+
+      (i) $x = -1, 0, 1, 2, 3$ corresponds to which range?
+      (ii) $x = 1, 2$ corresponds to which range?
+      (iii) $x = 0, 1, 2$ corresponds to which range?
     difficulty: medium
     learning_objective: 7.2.1
     answer:

--- a/curricula/malaysia/kssm/matematik-tingkatan2/topics/algebra/01-pola-dan-jujukan.assessments.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan2/topics/algebra/01-pola-dan-jujukan.assessments.yaml
@@ -141,7 +141,7 @@ questions:
       type: exact
       value: "19, 31"
       working: |
-        Find the difference between known consecutive terms: 13 - 7 = 6. 
+        Find the difference between known consecutive terms: 13 - 7 = 6.
         Pattern is add 6.
         13 + 6 = 19
         25 + 6 = 31
@@ -233,7 +233,7 @@ questions:
       type: free_text
       value: "Add 8 to the previous number."
       working: |
-        The change between terms is constant: 
+        The change between terms is constant:
         9 - 1 = 8
         17 - 9 = 8
         So the rule is add 8 repeatedly.

--- a/curricula/malaysia/kssm/matematik-tingkatan2/topics/algebra/02-pemfaktoran-dan-pecahan-algebra.assessments.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan2/topics/algebra/02-pemfaktoran-dan-pecahan-algebra.assessments.yaml
@@ -1,4 +1,4 @@
-﻿topic_id: F2-02
+topic_id: F2-02
 provenance: ai-assisted
 questions:
   - id: Q1
@@ -8,10 +8,10 @@ questions:
     answer:
       type: exact
       value: "3x + 12"
-    working: |
-      Distribute 3 to each term inside the bracket:
-      3(x) + 3(4)
-      = 3x + 12
+      working: |
+        Distribute 3 to each term inside the bracket:
+        3(x) + 3(4)
+        = 3x + 12
     marks: 2
     rubric:
       - marks: 1
@@ -29,11 +29,11 @@ questions:
     answer:
       type: exact
       value: "x^2 - 3x - 10"
-    working: |
-      Multiply each term in the first bracket by each term in the second bracket:
-      x(x) + x(-5) + 2(x) + 2(-5)
-      = x^2 - 5x + 2x - 10
-      = x^2 - 3x - 10
+      working: |
+        Multiply each term in the first bracket by each term in the second bracket:
+        x(x) + x(-5) + 2(x) + 2(-5)
+        = x^2 - 5x + 2x - 10
+        = x^2 - 3x - 10
     marks: 2
     rubric:
       - marks: 1
@@ -51,14 +51,14 @@ questions:
     answer:
       type: exact
       value: "2x^2 - y^2 - 2xy"
-    working: |
-      Expand the first part (difference of squares):
-      (x + y)(x - y) = x^2 - y^2
-      Expand the second part:
-      x(x - 2y) = x^2 - 2xy
-      Combine both parts:
-      x^2 - y^2 + x^2 - 2xy
-      = 2x^2 - y^2 - 2xy
+      working: |
+        Expand the first part (difference of squares):
+        (x + y)(x - y) = x^2 - y^2
+        Expand the second part:
+        x(x - 2y) = x^2 - 2xy
+        Combine both parts:
+        x^2 - y^2 + x^2 - 2xy
+        = 2x^2 - y^2 - 2xy
     marks: 3
     rubric:
       - marks: 1
@@ -78,14 +78,14 @@ questions:
     answer:
       type: exact
       value: "6x + 10"
-    working: |
-      Expand the first product:
-      (x + 2)(x + 5) = x^2 + 5x + 2x + 10 = x^2 + 7x + 10
-      Expand the second product, taking care of the negative sign:
-      -x(x + 1) = -x^2 - x
-      Combine the terms:
-      (x^2 + 7x + 10) - x^2 - x
-      = 6x + 10
+      working: |
+        Expand the first product:
+        (x + 2)(x + 5) = x^2 + 5x + 2x + 10 = x^2 + 7x + 10
+        Expand the second product, taking care of the negative sign:
+        -x(x + 1) = -x^2 - x
+        Combine the terms:
+        (x^2 + 7x + 10) - x^2 - x
+        = 6x + 10
     marks: 3
     rubric:
       - marks: 1
@@ -105,13 +105,13 @@ questions:
     answer:
       type: exact
       value: "3r^2 + r - 2"
-    working: |
-      Area = length × width
-      Area = (3r - 2)(r + 1)
-      Expand the brackets:
-      = 3r(r) + 3r(1) - 2(r) - 2(1)
-      = 3r^2 + 3r - 2r - 2
-      = 3r^2 + r - 2
+      working: |
+        Area = length × width
+        Area = (3r - 2)(r + 1)
+        Expand the brackets:
+        = 3r(r) + 3r(1) - 2(r) - 2(1)
+        = 3r^2 + 3r - 2r - 2
+        = 3r^2 + r - 2
     marks: 3
     rubric:
       - marks: 1
@@ -131,13 +131,13 @@ questions:
     answer:
       type: exact
       value: "4x(2 + 3x)"
-    working: |
-      Find the Highest Common Factor (HCF) for the numbers 8 and 12, which is 4.
-      Find the HCF for variables x and x^2, which is x.
-      Extract 4x:
-      8x / 4x = 2
-      12x^2 / 4x = 3x
-      = 4x(2 + 3x)
+      working: |
+        Find the Highest Common Factor (HCF) for the numbers 8 and 12, which is 4.
+        Find the HCF for variables x and x^2, which is x.
+        Extract 4x:
+        8x / 4x = 2
+        12x^2 / 4x = 3x
+        = 4x(2 + 3x)
     marks: 2
     rubric:
       - marks: 1
@@ -155,10 +155,10 @@ questions:
     answer:
       type: exact
       value: "(b + 9)(b - 9)"
-    working: |
-      Recognize that 81 is a perfect square (9^2).
-      Apply the difference of squares rule: a^2 - b^2 = (a + b)(a - b)
-      b^2 - 9^2 = (b + 9)(b - 9)
+      working: |
+        Recognize that 81 is a perfect square (9^2).
+        Apply the difference of squares rule: a^2 - b^2 = (a + b)(a - b)
+        b^2 - 9^2 = (b + 9)(b - 9)
     marks: 2
     rubric:
       - marks: 1
@@ -176,14 +176,14 @@ questions:
     answer:
       type: exact
       value: "(x + 2)(x + 4)"
-    working: |
-      Find factors of x^2: x and x
-      Find factors of 8 that add up to 6: 2 and 4
-      Cross multiply: 
-      x * 4 = 4x
-      x * 2 = 2x
-      Sum = 6x (matches the middle term)
-      Result = (x + 2)(x + 4)
+      working: |
+        Find factors of x^2: x and x
+        Find factors of 8 that add up to 6: 2 and 4
+        Cross multiply:
+        x * 4 = 4x
+        x * 2 = 2x
+        Sum = 6x (matches the middle term)
+        Result = (x + 2)(x + 4)
     marks: 3
     rubric:
       - marks: 1
@@ -203,13 +203,13 @@ questions:
     answer:
       type: exact
       value: "(q + s)(p + r)"
-    working: |
-      Group the terms into pairs with common factors:
-      (pq + qr) + (ps + rs)
-      Extract the common factor from each pair:
-      q(p + r) + s(p + r)
-      Extract the common bracket (p + r):
-      = (p + r)(q + s)  OR  (q + s)(p + r)
+      working: |
+        Group the terms into pairs with common factors:
+        (pq + qr) + (ps + rs)
+        Extract the common factor from each pair:
+        q(p + r) + s(p + r)
+        Extract the common bracket (p + r):
+        = (p + r)(q + s) OR (q + s)(p + r)
     marks: 3
     rubric:
       - marks: 1
@@ -229,15 +229,15 @@ questions:
     answer:
       type: exact
       value: "x + 4"
-    working: |
-      Length = Area / Width
-      Length = (4x^2 + 16x) / 4x
-      Factorise the numerator (Area) using HCF:
-      4x^2 + 16x = 4x(x + 4)
-      Divide by the denominator (Width):
-      = 4x(x + 4) / 4x
-      Cancel the common factor 4x:
-      = x + 4
+      working: |
+        Length = Area / Width
+        Length = (4x^2 + 16x) / 4x
+        Factorise the numerator (Area) using HCF:
+        4x^2 + 16x = 4x(x + 4)
+        Divide by the denominator (Width):
+        = 4x(x + 4) / 4x
+        Cancel the common factor 4x:
+        = x + 4
     marks: 3
     rubric:
       - marks: 1
@@ -257,10 +257,10 @@ questions:
     answer:
       type: exact
       value: "\\frac{7a}{5}"
-    working: |
-      Since the denominators are the same (5), combine the numerators directly:
-      (4a + 3a) / 5
-      = 7a / 5
+      working: |
+        Since the denominators are the same (5), combine the numerators directly:
+        (4a + 3a) / 5
+        = 7a / 5
     marks: 2
     rubric:
       - marks: 1
@@ -278,13 +278,13 @@ questions:
     answer:
       type: exact
       value: "\\frac{6 - 4s}{9}"
-    working: |
-      Find the common denominator for 3 and 9, which is 9.
-      Multiply the numerator and denominator of the first fraction by 3:
-      = (2 * 3) / (3 * 3) - 4s / 9
-      = 6 / 9 - 4s / 9
-      Combine over the common denominator:
-      = (6 - 4s) / 9
+      working: |
+        Find the common denominator for 3 and 9, which is 9.
+        Multiply the numerator and denominator of the first fraction by 3:
+        = (2 * 3) / (3 * 3) - 4s / 9
+        = 6 / 9 - 4s / 9
+        Combine over the common denominator:
+        = (6 - 4s) / 9
     marks: 3
     rubric:
       - marks: 1
@@ -304,16 +304,16 @@ questions:
     answer:
       type: exact
       value: "\\frac{b(a - 1)}{2a}"
-    working: |
-      Factorise the numerator a^2 - 1 (difference of squares):
-      = (a + 1)(a - 1)
-      Substitute into the equation:
-      = [(a + 1)(a - 1) / 2ab] * [b^2 / (1 + a)]
-      Note that (1 + a) is the same as (a + 1).
-      Cancel the common factor (a + 1).
-      Cancel the common factor b from b^2 and 2ab:
-      = (a - 1) * b / 2a
-      = b(a - 1) / 2a
+      working: |
+        Factorise the numerator a^2 - 1 (difference of squares):
+        = (a + 1)(a - 1)
+        Substitute into the equation:
+        = [(a + 1)(a - 1) / 2ab] * [b^2 / (1 + a)]
+        Note that (1 + a) is the same as (a + 1).
+        Cancel the common factor (a + 1).
+        Cancel the common factor b from b^2 and 2ab:
+        = (a - 1) * b / 2a
+        = b(a - 1) / 2a
     marks: 3
     rubric:
       - marks: 1
@@ -333,14 +333,14 @@ questions:
     answer:
       type: exact
       value: "\\frac{x + y}{m + n}"
-    working: |
-      Change division to multiplication by flipping the second fraction:
-      = [(m + n) / (x - y)] * [(x^2 - y^2) / (m + n)^2]
-      Factorise x^2 - y^2 into (x + y)(x - y):
-      = [(m + n) / (x - y)] * [(x + y)(x - y) / (m + n)(m + n)]
-      Cancel the common factor (x - y):
-      Cancel the common factor (m + n):
-      = (x + y) / (m + n)
+      working: |
+        Change division to multiplication by flipping the second fraction:
+        = [(m + n) / (x - y)] * [(x^2 - y^2) / (m + n)^2]
+        Factorise x^2 - y^2 into (x + y)(x - y):
+        = [(m + n) / (x - y)] * [(x + y)(x - y) / (m + n)(m + n)]
+        Cancel the common factor (x - y):
+        Cancel the common factor (m + n):
+        = (x + y) / (m + n)
     marks: 4
     rubric:
       - marks: 1
@@ -362,23 +362,23 @@ questions:
     answer:
       type: exact
       value: "\\frac{7a + 10b}{b}"
-    working: |
-      Solve the multiplication part first (BODMAS):
-      Method 1 (Expansion):
-      = [2(15a) / 5b] + [2(25b) / 5b] + a/b
-      = 30a/5b + 50b/5b + a/b
-      = 6a/b + 10 + a/b
-      To combine, ensure same denominator:
-      = (6a + 10b + a) / b
-      = (7a + 10b) / b
-      
-      Method 2 (Factorisation):
-      Factorise 5 out of (15a + 25b): 5(3a + 5b)
-      = (2 / 5b) * 5(3a + 5b) + a/b
-      Cancel the 5s:
-      = 2(3a + 5b) / b + a/b
-      = (6a + 10b) / b + a/b
-      = (7a + 10b) / b
+      working: |
+        Solve the multiplication part first (BODMAS):
+        Method 1 (Expansion):
+        = [2(15a) / 5b] + [2(25b) / 5b] + a/b
+        = 30a/5b + 50b/5b + a/b
+        = 6a/b + 10 + a/b
+        To combine, ensure same denominator:
+        = (6a + 10b + a) / b
+        = (7a + 10b) / b
+
+        Method 2 (Factorisation):
+        Factorise 5 out of (15a + 25b): 5(3a + 5b)
+        = (2 / 5b) * 5(3a + 5b) + a/b
+        Cancel the 5s:
+        = 2(3a + 5b) / b + a/b
+        = (6a + 10b) / b + a/b
+        = (7a + 10b) / b
     marks: 4
     rubric:
       - marks: 1

--- a/curricula/malaysia/kssm/matematik-tingkatan2/topics/algebra/03-rumus-algebra.assessments.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan2/topics/algebra/03-rumus-algebra.assessments.yaml
@@ -5,14 +5,14 @@ questions:
     text: "The perimeter of a rectangle is given by $P = 2l + 2w$. If $l = 7$ and $w = 4$, find $P$."
     difficulty: easy
     learning_objective: 3.1.3
-    answer: 
+    answer:
       type: exact
       value: "22"
-    working: |
-      Substitute l = 7 and w = 4:
-      P = 2(7) + 2(4)
-      P = 14 + 8
-      P = 22
+      working: |
+        Substitute l = 7 and w = 4:
+        P = 2(7) + 2(4)
+        P = 14 + 8
+        P = 22
     marks: 2
     rubric:
       - marks: 1
@@ -27,13 +27,13 @@ questions:
     text: "Write a formula for total cost $C$ if each notebook costs RMm and you buy n notebooks."
     difficulty: easy
     learning_objective: 3.1.1
-    answer: 
+    answer:
       type: exact
       value: "C = mn"
-    working: |
-      Total cost equals unit price multiplied by quantity.
-      Therefore C = m * n
-      C = mn
+      working: |
+        Total cost equals unit price multiplied by quantity.
+        Therefore C = m * n
+        C = mn
     marks: 1
     rubric:
       - marks: 1
@@ -46,13 +46,13 @@ questions:
     text: "Make $x$ the subject of the formula: $y = 3x - 8$."
     difficulty: medium
     learning_objective: 3.1.2
-    answer: 
+    answer:
       type: exact
       value: "x = (y + 8) / 3"
-    working: |
-      y = 3x - 8
-      y + 8 = 3x
-      x = (y + 8) / 3
+      working: |
+        y = 3x - 8
+        y + 8 = 3x
+        x = (y + 8) / 3
     marks: 2
     rubric:
       - marks: 1
@@ -67,37 +67,37 @@ questions:
     text: "Given the formula $L = \\pi j^2$, make $j$ the subject of the formula."
     difficulty: medium
     learning_objective: 3.1.2
-    answer: 
+    answer:
       type: exact
       value: "j = \\sqrt{L / \\pi}"
-    working: |
-      L = \pi j^2
-      j^2 = L / \pi
-      j = \sqrt{L / \pi}
+      working: |
+        L = \pi j^2
+        j^2 = L / \pi
+        j = \sqrt{L / \pi}
     marks: 3
     rubric:
       - marks: 1
-        criteria: "Rearranges equation to isolate j^2 by dividing both sides by \pi."
+        criteria: "Rearranges equation to isolate j^2 by dividing both sides by \\pi."
       - marks: 1
         criteria: "Applies square root to the entire opposite side."
       - marks: 1
         criteria: "States the final correct formula for j."
     hints:
       - level: 1
-        text: "First isolate j^2 by removing \pi. Then remember that the opposite of squaring is finding the square root."
+        text: "First isolate j^2 by removing \\pi. Then remember that the opposite of squaring is finding the square root."
 
   - id: Q5
     text: "A taxi fare formula is $F = 4 + 1.8d$, where $F$ is fare in RM and $d$ is distance in km. If a passenger pays RM22, find the distance travelled."
     difficulty: hard
     learning_objective: 3.1.4
-    answer: 
+    answer:
       type: exact
       value: "10"
-    working: |
-      22 = 4 + 1.8d
-      18 = 1.8d
-      d = 18 / 1.8
-      d = 10
+      working: |
+        22 = 4 + 1.8d
+        18 = 1.8d
+        d = 18 / 1.8
+        d = 10
     marks: 4
     rubric:
       - marks: 1

--- a/curricula/malaysia/kssm/matematik-tingkatan3/subjects/algebra.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan3/subjects/algebra.yaml
@@ -1,0 +1,7 @@
+id: algebra
+name: "Algebra"
+syllabus_id: malaysia-kssm-matematik-tingkatan3
+description: "Algebraic concepts for Form 3 KSSM Matematik including indices and straight lines (DSKP Bab 1 and 9)"
+topics:
+  - F3-01
+  - F3-09

--- a/curricula/malaysia/kssm/matematik-tingkatan3/syllabus.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan3/syllabus.yaml
@@ -1,0 +1,22 @@
+id: malaysia-kssm-matematik-tingkatan3
+name: "KSSM Matematik Tingkatan 3"
+board: malaysia
+level: kssm
+code: matematik-tingkatan3
+version: "2017"
+subjects:
+  - algebra
+
+assessment:
+  components:
+    - name: "Pentaksiran Bilik Darjah (PBD)"
+      weight: 1.0
+
+grading:
+  scale:
+    - "Tahap Penguasaan 6 (Cemerlang)"
+    - "Tahap Penguasaan 5 (Kepujian)"
+    - "Tahap Penguasaan 4 (Baik)"
+    - "Tahap Penguasaan 3 (Memuaskan)"
+    - "Tahap Penguasaan 2 (Sederhana)"
+    - "Tahap Penguasaan 1 (Lemah)"

--- a/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/01-indeks.assessments.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/01-indeks.assessments.yaml
@@ -1,0 +1,111 @@
+topic_id: F3-01
+provenance: ai-assisted
+questions:
+  - id: Q1
+    text: "Write $5 \\times 5 \\times 5 \\times 5$ in index form and state the base and the index."
+    difficulty: easy
+    learning_objective: 1.1.1
+    answer:
+      type: exact
+      value: "5^4; base = 5; index = 4"
+      working: |
+        Four factors of 5 are multiplied together.
+        So the repeated multiplication is written as 5^4.
+        The base is 5 and the index is 4.
+    marks: 2
+    rubric:
+      - marks: 1
+        criteria: "Writes the correct index form 5^4."
+      - marks: 1
+        criteria: "States base 5 and index 4 correctly."
+    hints:
+      - level: 1
+        text: "Count how many times the same factor appears."
+
+  - id: Q2
+    text: "Simplify $3^2 \\times 3^5$."
+    difficulty: easy
+    learning_objective: 1.2.1
+    answer:
+      type: exact
+      value: "3^7"
+      working: |
+        When multiplying numbers in index form with the same base, add the indices.
+        3^2 × 3^5 = 3^(2+5) = 3^7
+    marks: 2
+    rubric:
+      - marks: 1
+        criteria: "Keeps the base as 3."
+      - marks: 1
+        criteria: "Adds the indices to obtain 7."
+    hints:
+      - level: 1
+        text: "The base stays the same. Combine the number of factors."
+
+  - id: Q3
+    text: "Simplify $2^6 \\div 2^2$."
+    difficulty: medium
+    learning_objective: 1.2.2
+    answer:
+      type: exact
+      value: "2^4"
+      working: |
+        When dividing numbers in index form with the same base, subtract the indices.
+        2^6 ÷ 2^2 = 2^(6-2) = 2^4
+    marks: 2
+    rubric:
+      - marks: 1
+        criteria: "Uses subtraction of indices correctly."
+      - marks: 1
+        criteria: "States the simplified answer 2^4."
+    hints:
+      - level: 1
+        text: "Division with the same base means reducing the number of repeated factors."
+
+  - id: Q4
+    text: "Simplify and give your answer without negative indices: $4^{-2}$."
+    difficulty: medium
+    learning_objective: 1.2.4
+    answer:
+      type: exact
+      value: "1/16"
+      working: |
+        A negative index means reciprocal.
+        4^-2 = 1 / 4^2
+        = 1 / 16
+    marks: 3
+    rubric:
+      - marks: 1
+        criteria: "Recognizes the reciprocal for a negative index."
+      - marks: 1
+        criteria: "Evaluates 4^2 correctly."
+      - marks: 1
+        criteria: "Gives the final answer 1/16."
+    hints:
+      - level: 1
+        text: "First rewrite with a positive index in the denominator."
+
+  - id: Q5
+    text: "Simplify $81^{1/2} + 8^{1/3}$."
+    difficulty: hard
+    learning_objective: 1.2.5
+    answer:
+      type: exact
+      value: "11"
+      working: |
+        81^(1/2) = √81 = 9
+        8^(1/3) = ∛8 = 2
+        Therefore 9 + 2 = 11
+    marks: 4
+    rubric:
+      - marks: 1
+        criteria: "Identifies 81^(1/2) as the square root of 81."
+      - marks: 1
+        criteria: "Identifies 8^(1/3) as the cube root of 8."
+      - marks: 1
+        criteria: "Evaluates both terms correctly."
+      - marks: 1
+        criteria: "Finds the final total of 11."
+    hints:
+      - level: 1
+        text: "Recall that index 1/2 means square root and 1/3 means cube root."

--- a/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/01-indeks.teaching.md
+++ b/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/01-indeks.teaching.md
@@ -1,0 +1,78 @@
+# Bab 1: Indeks (Indices) — Teaching Notes
+
+## Overview
+This chapter tightens students' number sense by moving them from repeated multiplication to compact symbolic reasoning. "Indeks" is not just notation; it is a rule system that later supports standard form, scientific notation, algebraic manipulation, and exponential relationships. Students need both conceptual pattern recognition and careful procedural fluency.
+
+## DSKP Anchors & Taxonomy
+**Standard Kandungan & Pembelajaran:**
+- **SK 1.1 Tatatanda Indeks (Index Notation)**
+  - **1.1.1:** Mewakilkan pendaraban berulang dalam bentuk indeks dan menghuraikan maksudnya.
+  - **1.1.2:** Menukar suatu nombor kepada bentuk indeks dan sebaliknya.
+- **SK 1.2 Hukum Indeks (Law of Indices)**
+  - **1.2.1:** Menghubungkait pendaraban nombor dalam bentuk indeks yang mempunyai asas yang sama dengan pendaraban berulang dan seterusnya membuat generalisasi.
+  - **1.2.2:** Menghubungkait pembahagian nombor dalam bentuk indeks yang mempunyai asas yang sama dengan pendaraban berulang dan seterusnya membuat generalisasi.
+  - **1.2.3:** Menghubungkait nombor dalam bentuk indeks yang dikuasakan dengan pendaraban berulang dan seterusnya membuat generalisasi.
+  - **1.2.4:** Mengesahkan bahawa a^0 = 1 dan a^(-n) = 1 / (a^n), dengan keadaan a tidak sama dengan 0.
+  - **1.2.5:** Menentukan dan menyatakan hubungan antara indeks pecahan dengan punca dan kuasa.
+  - **1.2.6:** Melakukan operasi yang melibatkan hukum indeks.
+  - **1.2.7:** Menyelesaikan masalah yang melibatkan hukum indeks.
+
+## Prerequisites Check
+- Students can evaluate powers such as squares and cubes from earlier arithmetic/algebra work.
+- Students can factor and simplify basic algebraic forms, especially when recognizing repeated factors (F2-02).
+- Students can follow symbolic rules carefully without mixing coefficients, bases, and exponents.
+
+## Teaching Sequence & Strategy
+
+### 1. Tatatanda Indeks as compressed repeated multiplication (15-20 min)
+Start concrete. Write $2 \\times 2 \\times 2 \\times 2$ before writing $2^4$. Make students say aloud: base 2, index 4. Keep the meaning visible so notation never floats free from quantity.
+
+### 2. Build laws from patterns, not memorized slogans (25-30 min)
+Use tables of expansions:
+- $3^2 \\times 3^4 = (3 \\times 3)(3 \\times 3 \\times 3 \\times 3)$
+- $5^6 \\div 5^2$
+- $(2^3)^2$
+
+Only after expansion should students state rules like "same base, add indices." This reduces blind misuse.
+
+### 3. Zero, negative, and fractional indices as consistency rules (25 min)
+Teach these as extensions of earlier patterns:
+- $a^3 \\div a^3 = a^0 = 1$
+- stepping downward in powers explains negative indices
+- $a^{1/2}$ means "the number whose square is a"
+
+Students should see one coherent system, not three disconnected exceptions.
+
+### 4. Mixed operations and problem solving (20-25 min)
+Use expressions that require choosing the correct rule, not applying every rule at once. End with contexts such as area/volume scaling or scientific notation-style simplification so the laws feel useful.
+
+## High Alert Misconceptions
+
+| Misconception | Why Students Think This | How to Fix |
+| :--- | :--- | :--- |
+| **Adding bases instead of indices** | They memorize "add something" from multiplication with same base. | Force expansion first: $2^3 \\times 2^2 = 2^5$, not $4^5$. Ask "How many 2s are there altogether?" |
+| **Treating $a^0$ as 0** | Surface pattern matching: "anything with 0 becomes 0." | Use division pattern and numerical examples: $7^3 \\div 7^3 = 1$. |
+| **Negative index means negative value** | Students confuse sign with reciprocal. | Compare $2^{-2} = 1/4$ against $(-2)^2 = 4$ and discuss what the minus belongs to. |
+| **Fractional index seen as impossible** | They only associate indices with whole-number repetition. | Link directly to roots: $a^{1/2} = \\sqrt{a}$, $a^{1/3} = \\sqrt[3]{a}$. |
+
+## Engagement Hooks
+- **Pattern wall:** groups expand, simplify, and generalize one law each, then teach the class.
+- **True/false sprint:** show claims like $3^2 + 3^3 = 3^5$ and require fast justification.
+- **Card sort:** match equivalent forms such as $16^{1/2}$, $\\sqrt{16}$, and $4$.
+
+## Assessment Guidance
+- Include at least one item each for notation conversion, same-base operations, zero/negative indices, fractional indices, and a contextual problem.
+- Ask for justification in at least one rule-generalization question, not just final answers.
+- Watch whether students preserve bases correctly when simplifying.
+
+## Bilingual Key Terms
+
+| English | Bahasa Melayu |
+| :--- | :--- |
+| Index / exponent | Indeks |
+| Base | Asas |
+| Law of indices | Hukum indeks |
+| Repeated multiplication | Pendaraban berulang |
+| Negative index | Indeks negatif |
+| Fractional index | Indeks pecahan |
+| Root | Punca |

--- a/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/01-indeks.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/01-indeks.yaml
@@ -1,0 +1,59 @@
+id: F3-01
+name: "Indeks (Indices)"
+subject_id: algebra
+syllabus_id: malaysia-kssm-matematik-tingkatan3
+difficulty: intermediate
+tier: core
+
+learning_objectives:
+  - id: 1.1.1
+    text: "Represent repeated multiplication in index form and explain the meaning of base and index (SP 1.1.1)."
+    bloom: understand
+  - id: 1.1.2
+    text: "Convert between ordinary numerical expressions and index form accurately (SP 1.1.2)."
+    bloom: apply
+  - id: 1.2.1
+    text: "Generalize the law for multiplying numbers in index form with the same base from repeated multiplication patterns (SP 1.2.1)."
+    bloom: analyze
+  - id: 1.2.2
+    text: "Generalize the law for dividing numbers in index form with the same base from repeated multiplication patterns (SP 1.2.2)."
+    bloom: analyze
+  - id: 1.2.3
+    text: "Relate powers of numbers in index form to repeated multiplication and use the pattern to form a rule (SP 1.2.3)."
+    bloom: analyze
+  - id: 1.2.4
+    text: "Verify and use the meanings of zero and negative indices for non-zero bases (SP 1.2.4)."
+    bloom: apply
+  - id: 1.2.5
+    text: "Connect fractional indices with roots and powers in equivalent forms (SP 1.2.5)."
+    bloom: analyze
+  - id: 1.2.6
+    text: "Perform calculations involving the laws of indices accurately (SP 1.2.6)."
+    bloom: apply
+  - id: 1.2.7
+    text: "Solve contextual and non-routine problems involving the laws of indices with justified working (SP 1.2.7)."
+    bloom: analyze
+
+prerequisites:
+  required:
+    - F1-05
+    - F2-02
+  recommended:
+    - F2-03
+
+bloom_levels:
+  - understand
+  - apply
+  - analyze
+
+mastery:
+  minimum_score: 0.75
+  assessment_count: 3
+  spaced_repetition:
+    initial_interval_days: 3
+    multiplier: 2.5
+
+ai_teaching_notes: "01-indeks.teaching.md"
+assessments_file: "01-indeks.assessments.yaml"
+quality_level: 2
+provenance: ai-assisted

--- a/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/09-garis-lurus.assessments.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/09-garis-lurus.assessments.yaml
@@ -1,0 +1,125 @@
+topic_id: F3-09
+provenance: ai-assisted
+questions:
+  - id: Q1
+    text: "For the straight line $y = 3x - 4$, state the gradient and the y-intercept."
+    difficulty: easy
+    learning_objective: 9.1.1
+    answer:
+      type: exact
+      value: "gradient = 3; y-intercept = -4"
+      working: |
+        Compare y = 3x - 4 with y = mx + c.
+        Therefore m = 3 and c = -4.
+    marks: 2
+    rubric:
+      - marks: 1
+        criteria: "Identifies the gradient as 3."
+      - marks: 1
+        criteria: "Identifies the y-intercept as -4."
+    hints:
+      - level: 1
+        text: "Match the equation with the form y = mx + c."
+
+  - id: Q2
+    text: "Rewrite $2x + y = 7$ in the form $y = mx + c$."
+    difficulty: easy
+    learning_objective: 9.1.2
+    answer:
+      type: exact
+      value: "y = -2x + 7"
+      working: |
+        2x + y = 7
+        y = 7 - 2x
+        y = -2x + 7
+    marks: 2
+    rubric:
+      - marks: 1
+        criteria: "Rearranges to isolate y correctly."
+      - marks: 1
+        criteria: "Writes the final answer in y = mx + c form."
+    hints:
+      - level: 1
+        text: "Move 2x to the other side so y is alone."
+
+  - id: Q3
+    text: "Determine whether the point $(2, 5)$ lies on the line $y = 2x + 1$."
+    difficulty: medium
+    learning_objective: 9.1.3
+    answer:
+      type: exact
+      value: "Yes"
+      working: |
+        Substitute x = 2 into y = 2x + 1.
+        y = 2(2) + 1 = 5
+        The calculated y-value matches the point's y-coordinate.
+        Therefore (2, 5) lies on the line.
+    marks: 3
+    rubric:
+      - marks: 1
+        criteria: "Substitutes x = 2 correctly."
+      - marks: 1
+        criteria: "Obtains y = 5."
+      - marks: 1
+        criteria: "Makes the correct conclusion that the point lies on the line."
+    hints:
+      - level: 1
+        text: "Substitute the x-coordinate into the equation and compare the resulting y-value."
+
+  - id: Q4
+    text: "The line $y = -\\frac{1}{2}x + 6$ is parallel to line $k$. If line $k$ passes through $(4, 1)$, find the equation of line $k$ in the form $y = mx + c$."
+    difficulty: hard
+    learning_objective: 9.1.4
+    answer:
+      type: exact
+      value: "y = -1/2 x + 3"
+      working: |
+        Parallel lines have the same gradient.
+        So line k has gradient m = -1/2.
+        Substitute the point (4, 1) into y = -1/2 x + c:
+        1 = -1/2(4) + c
+        1 = -2 + c
+        c = 3
+        Therefore y = -1/2 x + 3
+    marks: 4
+    rubric:
+      - marks: 1
+        criteria: "Uses the same gradient for parallel lines."
+      - marks: 1
+        criteria: "Substitutes the point correctly."
+      - marks: 1
+        criteria: "Finds c = 3."
+      - marks: 1
+        criteria: "States the correct final equation."
+    hints:
+      - level: 1
+        text: "Start with the same gradient because the lines are parallel."
+
+  - id: Q5
+    text: "Find the point of intersection of the lines $y = x + 2$ and $y = -2x + 8$."
+    difficulty: hard
+    learning_objective: 9.1.6
+    answer:
+      type: exact
+      value: "(2, 4)"
+      working: |
+        At the point of intersection, both equations have the same y-value.
+        So x + 2 = -2x + 8
+        3x = 6
+        x = 2
+        Substitute into y = x + 2:
+        y = 2 + 2 = 4
+        Therefore the point of intersection is (2, 4).
+    marks: 4
+    rubric:
+      - marks: 1
+        criteria: "Equates the two expressions for y correctly."
+      - marks: 1
+        criteria: "Solves for x = 2."
+      - marks: 1
+        criteria: "Finds y = 4 by substitution."
+      - marks: 1
+        criteria: "States the point of intersection correctly."
+    hints:
+      - level: 1
+        text: "At the intersection, both equations give the same value of y."

--- a/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/09-garis-lurus.teaching.md
+++ b/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/09-garis-lurus.teaching.md
@@ -1,0 +1,69 @@
+# Bab 9: Garis Lurus (Straight Lines) — Teaching Notes
+
+## Overview
+This chapter is where algebra becomes visual. Students connect symbolic equations to graphs, interpret gradient as rate of change, and understand intercepts as meaningful positions on axes. "Garis Lurus" prepares them for coordinate geometry, functions, and later analytic thinking in science and economics.
+
+## DSKP Anchors & Taxonomy
+**Standard Kandungan & Pembelajaran:**
+- **SK 9.1 Garis Lurus (Straight Lines)**
+  - **9.1.1:** Membuat perkaitan antara persamaan, y = mx + c, dengan kecerunan dan pintasan-y dan seterusnya membuat generalisasi tentang persamaan garis lurus.
+  - **9.1.2:** Menyiasat dan mentafsir persamaan garis lurus dalam bentuk lain seperti ax + by = c dan x/a + y/b = 1, dan menukarkannya kepada bentuk y = mx + c, dan sebaliknya.
+  - **9.1.3:** Menyiasat dan membuat inferens tentang hubungan antara titik pada garis lurus dengan persamaan garis itu.
+  - **9.1.4:** Menyiasat dan membuat inferens tentang kecerunan garis lurus yang selari.
+  - **9.1.5:** Menentukan persamaan suatu garis lurus.
+  - **9.1.6:** Menentukan titik persilangan antara dua garis lurus.
+  - **9.1.7:** Menyelesaikan masalah yang melibatkan garis lurus.
+
+## Prerequisites Check
+- Students can solve linear equations and rearrange formulae confidently (F1-06, F2-03).
+- Students can work with ordered pairs on the Cartesian plane from prior coordinate work.
+- Students understand substitution and can verify whether a point satisfies an equation.
+
+## Teaching Sequence & Strategy
+
+### 1. Make y = mx + c visual and verbal (20 min)
+Do not begin with memorization. Plot two or three simple lines and ask:
+- which line rises faster?
+- where does each line cross the y-axis?
+
+Only then label gradient as $m$ and y-intercept as $c$. Students should see the graph and equation as two views of one object.
+
+### 2. Move between equation forms fluently (20-25 min)
+Teach conversion as purposeful rewriting, not symbol shuffling. When converting $ax + by = c$ into $y = mx + c$, narrate what each step reveals about gradient and intercept. Use intercept form to tie directly to x- and y-axis crossings.
+
+### 3. Points, equations, and line construction (25 min)
+Given a point, ask if it lies on the line by substitution. Given gradient and a point, ask students to build the equation. This reinforces that an equation describes every point on the line, not just one plotted picture.
+
+### 4. Parallel lines and intersections (20-25 min)
+Use side-by-side graphs to let students notice equal gradients in parallel lines. Then solve simultaneous line pairs for intersections and connect the algebraic solution to the single crossing point on the graph.
+
+## High Alert Misconceptions
+
+| Misconception | Why Students Think This | How to Fix |
+| :--- | :--- | :--- |
+| **Confusing gradient with intercept** | Both appear in the same equation and are introduced together. | Use color-coding: keep $m$ tied to "rise over run" and $c$ tied to axis crossing. |
+| **Assuming every equation is already in usable form** | Students over-rely on y = mx + c examples. | Regularly convert from ax + by = c and intercept form before interpreting. |
+| **Using different gradients for parallel lines** | Visual intuition is weak when lines are shifted up/down. | Compare tables/graphs showing same steepness, different intercepts. |
+| **Intersection found by guessing from graph only** | They trust sketch accuracy too much. | Require substitution/elimination to confirm the exact coordinate. |
+
+## Engagement Hooks
+- **Gradient race:** students rank line cards from steepest positive to steepest negative without plotting software first.
+- **Line detective:** give an equation and a shortlist of possible graphs; students justify the match.
+- **City map task:** interpret roads as straight lines and find where two routes meet.
+
+## Assessment Guidance
+- Include at least one interpretation item, one conversion-between-forms item, one equation-building item, one parallel-lines item, and one intersection problem.
+- Check explanation quality, not only numeric output: can students state what the gradient means in context?
+- Use at least one question where students test whether a point lies on a line.
+
+## Bilingual Key Terms
+
+| English | Bahasa Melayu |
+| :--- | :--- |
+| Straight line | Garis lurus |
+| Gradient | Kecerunan |
+| y-intercept | Pintasan-y |
+| x-intercept | Pintasan-x |
+| Equation of a line | Persamaan garis lurus |
+| Parallel lines | Garis selari |
+| Point of intersection | Titik persilangan |

--- a/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/09-garis-lurus.yaml
+++ b/curricula/malaysia/kssm/matematik-tingkatan3/topics/algebra/09-garis-lurus.yaml
@@ -1,0 +1,53 @@
+id: F3-09
+name: "Garis Lurus (Straight Lines)"
+subject_id: algebra
+syllabus_id: malaysia-kssm-matematik-tingkatan3
+difficulty: intermediate
+tier: core
+
+learning_objectives:
+  - id: 9.1.1
+    text: "Relate the equation y = mx + c to gradient and y-intercept, then generalize its meaning (SP 9.1.1)."
+    bloom: understand
+  - id: 9.1.2
+    text: "Convert equations of straight lines between forms such as y = mx + c, ax + by = c, and x/a + y/b = 1 (SP 9.1.2)."
+    bloom: apply
+  - id: 9.1.3
+    text: "Infer the relationship between points on a straight line and the equation of the line (SP 9.1.3)."
+    bloom: analyze
+  - id: 9.1.4
+    text: "Investigate and infer the relationship between the gradients of parallel straight lines (SP 9.1.4)."
+    bloom: analyze
+  - id: 9.1.5
+    text: "Determine the equation of a straight line from suitable given information (SP 9.1.5)."
+    bloom: apply
+  - id: 9.1.6
+    text: "Determine the point of intersection of two straight lines accurately (SP 9.1.6)."
+    bloom: apply
+  - id: 9.1.7
+    text: "Solve contextual problems involving straight lines and interpret the result correctly (SP 9.1.7)."
+    bloom: analyze
+
+prerequisites:
+  required:
+    - F1-06
+    - F2-03
+  recommended:
+    - F2-01
+
+bloom_levels:
+  - understand
+  - apply
+  - analyze
+
+mastery:
+  minimum_score: 0.75
+  assessment_count: 3
+  spaced_repetition:
+    initial_interval_days: 3
+    multiplier: 2.5
+
+ai_teaching_notes: "09-garis-lurus.teaching.md"
+assessments_file: "09-garis-lurus.assessments.yaml"
+quality_level: 2
+provenance: ai-assisted


### PR DESCRIPTION
## Summary
This change brings the planned Form 3 KSSM Matematik algebra slice into `oss` and clears the assessment validation debt that was blocking the repo gate. Form 3 was still missing from the curriculum tree even though the development timeline calls for `matematik-tingkatan3` scaffolding plus the two algebra topics `F3-01 Indeks` and `F3-09 Garis Lurus`.

## Problem
The repository state had diverged from the documented plan. Form 1 and Form 2 algebra content existed, but Form 3 algebra had not been added. At the same time, several existing assessment YAML files still violated the current schema and lint rules, so `bash scripts/validate.sh` failed even before new Form 3 content could be considered ready.

## Root Cause
Two issues were present:

1. The Form 3 curriculum scaffold and topic assets had simply not been landed yet.
2. Some existing assessment files still used the older top-level `working` field layout or contained formatting issues such as long lines, trailing spaces, and an invalid `\pi` escape inside a double-quoted YAML string.

## Fix
This PR adds the full Form 3 algebra scaffold under `curricula/malaysia/kssm/matematik-tingkatan3/`, including:

- syllabus metadata
- algebra subject metadata
- topic YAMLs for `F3-01 Indeks` and `F3-09 Garis Lurus`
- teaching notes for both topics
- initial assessment sets for both topics

The Form 3 topic structure was aligned to the local `s_rpt` DSKP source for Bab 1 and Bab 9, and prerequisites were linked back to the existing Form 1 and Form 2 algebra sequence.

This PR also normalizes the existing Form 1 and Form 2 assessment files so they validate under the current schema and lint rules. That includes moving `working` under `answer` where required, fixing YAML escaping, removing trailing spaces, and wrapping overlong strings.

## Validation
I ran the full local validation gate:

```bash
bash scripts/validate.sh
```

Result: all validations passed.
