### PR TITLE
[codex] fix MT2 assessment lint wrap

### DIFF
--- a/curricula/malaysia/malaysia-kssm/malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.assessments.yaml
+++ b/curricula/malaysia/malaysia-kssm/malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.assessments.yaml
@@ -532,9 +532,6 @@ questions:
       - level: 1
         text: "Count the number of pencils in each group first to create a number sequence."
 
-  ### ---------------------------------------------------------
-  ### NEW ADDITIONS TO MEET 5-5-5 POOL MINIMUM
-  ### ---------------------------------------------------------
   - id: Q22
     # EXAM: UASA Bahagian C (Subjektif)
     # RATIONALE: Non-routine visual pattern requiring algebraic generalization (n=1, 2, 3...).

--- a/curricula/malaysia/malaysia-kssm/malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.assessments.yaml
+++ b/curricula/malaysia/malaysia-kssm/malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.assessments.yaml
@@ -538,7 +538,11 @@ questions:
   - id: Q22
     # EXAM: UASA Bahagian C (Subjektif)
     # RATIONALE: Non-routine visual pattern requiring algebraic generalization (n=1, 2, 3...).
-    text: "A pattern is formed using square tiles. The first pattern ($n=1$) has 1 tile, the second ($n=2$) has 4 tiles, the third ($n=3$) has 7 tiles, and so on. Form an algebraic expression to represent the number of tiles in the $n$-th pattern."
+    text: >-
+      A pattern is formed using square tiles. The first pattern ($n=1$) has 1 tile,
+      the second ($n=2$) has 4 tiles, the third ($n=3$) has 7 tiles, and so on.
+      Form an algebraic expression to represent the number of tiles in the
+      $n$-th pattern.
     difficulty: hard
     tp_level: 5
     kbat: true


### PR DESCRIPTION
## What changed

Wrapped the MT2-01 Q22 assessment prompt into a folded YAML scalar so it stays under the repository yamllint line-length limit without changing the question content.

## Why

The current canonical Form 2 Pola dan Jujukan assessment file still had a long scalar in Q22. Q17 was already fixed on GitHub main after syncing, so this PR keeps the remaining same-file lint fix scoped.

## Impact

This is content-formatting only. The assessment text and schema meaning are unchanged.

## Validation

- `yamllint -c .yamllint.yml curricula/malaysia/malaysia-kssm/malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.assessments.yaml`
- `ajv validate --spec=draft2020 -s schema/assessments.schema.json -d curricula/malaysia/malaysia-kssm/malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.assessments.yaml`

Note: full `./scripts/validate.sh` still fails on existing unrelated main issues across other curriculum files and validators.
