### PR TITLE
ci: validate changed files in PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,9 +1,18 @@
 name: Validate Curriculum
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    env:
+      UV_TOOL_DIR: ${{ github.workspace }}/.ci/uv/tools
+      UV_TOOL_BIN_DIR: ${{ github.workspace }}/.ci/uv/bin
+      NPM_CONFIG_PREFIX: ${{ github.workspace }}/.ci/npm-prefix
     steps:
       - uses: actions/checkout@v4
 
@@ -12,15 +21,58 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
+          enable-cache: true
+          tool-dir: ${{ env.UV_TOOL_DIR }}
+          tool-bin-dir: ${{ env.UV_TOOL_BIN_DIR }}
+
+      - name: Restore validation tools
+        id: validation-tools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .ci/uv/tools
+            .ci/uv/bin
+            .ci/npm-prefix
+          key: validation-tools-${{ runner.os }}-uv-yamllint-ajv-v1
 
       - name: Install validators
         run: |
-          npm install -g ajv-cli ajv-formats
-          pip install yamllint
+          mkdir -p "$UV_TOOL_DIR" "$UV_TOOL_BIN_DIR" "$NPM_CONFIG_PREFIX"
+          echo "$UV_TOOL_BIN_DIR" >> "$GITHUB_PATH"
+          echo "$NPM_CONFIG_PREFIX/bin" >> "$GITHUB_PATH"
+          export PATH="$UV_TOOL_BIN_DIR:$NPM_CONFIG_PREFIX/bin:$PATH"
+
+          uv python install 3.12
+
+          if ! command -v yamllint >/dev/null; then
+            uv tool install yamllint
+          fi
+
+          if ! command -v ajv >/dev/null; then
+            npm install --global ajv-cli ajv-formats
+          fi
+
+          yamllint --version
+          ajv help >/dev/null
+
+      - name: Save validation tools
+        if: steps.validation-tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .ci/uv/tools
+            .ci/uv/bin
+            .ci/npm-prefix
+          key: validation-tools-${{ runner.os }}-uv-yamllint-ajv-v1
+
+      - name: Run changed files validation
+        if: github.event_name == 'pull_request'
+        run: ./scripts/validate-changed.sh
 
       - name: Run full validation
+        if: github.event_name != 'pull_request'
         run: ./scripts/validate.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: "20"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
           enable-cache: true

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ oss/
 │
 ├── scripts/                          # CI and maintenance scripts
 │   ├── validate.sh
+│   ├── validate-changed.sh
 │   ├── check-prerequisites.rb
 │   ├── check-references.rb
 │   ├── assess-quality.rb
@@ -435,7 +436,8 @@ A pre-built SQLite database (50-200MB) containing all curriculum data, for offli
 All YAML files are validated against JSON Schemas in the `schema/` directory.
 
 ```bash
-# Install the validator
+# Install validators
+uv tool install yamllint
 npm install -g ajv-cli ajv-formats
 
 # Validate a single topic (--spec=draft2020 required for Draft 2020-12)
@@ -445,7 +447,7 @@ ajv validate --spec=draft2020 -s schema/topic.schema.json -d "curricula/cambridg
 find curricula/cambridge -name "*.yaml" -path "*/topics/*" | xargs -I{} ajv validate --spec=draft2020 -s schema/topic.schema.json -d {}
 ```
 
-The CI pipeline validates every file on every pull request. Invalid files cannot be merged.
+Pull request CI validates only changed validation-relevant files so scoped fixes are not blocked by existing full-repo failures. Pushes to `main` and manual workflow runs execute the full `./scripts/validate.sh` gate.
 
 ---
 

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -36,8 +36,11 @@ node --version   # Expected: v20.x.x
 # Ruby (for custom validation scripts)
 ruby --version   # Expected: system Ruby or newer
 
+# uv (Python tool installer/cache; CI uses astral-sh/setup-uv)
+uv --version
+
 # yamllint (YAML linter)
-pip install yamllint
+uv tool install yamllint
 yamllint --version   # Expected: ≥1.35
 
 # ajv-cli (JSON Schema validator)
@@ -48,8 +51,8 @@ ajv --version   # Expected: ≥5.0.0
 ### Verify Setup
 
 ```bash
-# All four should succeed without errors
-node --version && ruby --version && yamllint --version && ajv help
+# All five should succeed without errors
+node --version && ruby --version && uv --version && yamllint --version && ajv help
 ```
 
 ---
@@ -1088,7 +1091,8 @@ done
 |---|------|-------|---------------|--------|
 | 3.1 | Create GitHub Actions `validate.yml` | 🤖 | `.github/workflows/validate.yml` | ✅ Done |
 | 3.2 | Create `scripts/validate.sh` | 🤖 | `scripts/validate.sh` | ✅ Done |
-| 3.3 | Run full validation, fix any failures | 🤖 | — | ✅ Done |
+| 3.3 | Create changed-files PR validation | 🤖 | `scripts/validate-changed.sh` | ✅ Done |
+| 3.4 | Run full validation, fix any failures | 🤖 | — | ✅ Done |
 
 #### 3.1 — GitHub Actions Workflow
 
@@ -1096,11 +1100,20 @@ done
 
 ```yaml
 name: Validate Curriculum
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    env:
+      UV_TOOL_DIR: ${{ github.workspace }}/.ci/uv/tools
+      UV_TOOL_BIN_DIR: ${{ github.workspace }}/.ci/uv/bin
+      NPM_CONFIG_PREFIX: ${{ github.workspace }}/.ci/npm-prefix
     steps:
       - uses: actions/checkout@v4
 
@@ -1109,69 +1122,36 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
+          enable-cache: true
+          tool-dir: ${{ env.UV_TOOL_DIR }}
+          tool-bin-dir: ${{ env.UV_TOOL_BIN_DIR }}
+
+      - name: Restore validation tools
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .ci/uv/tools
+            .ci/uv/bin
+            .ci/npm-prefix
+          key: validation-tools-${{ runner.os }}-uv-yamllint-ajv-v1
 
       - name: Install validators
         run: |
-          npm install -g ajv-cli ajv-formats
-          pip install yamllint
+          uv python install 3.12
+          uv tool install yamllint
+          npm install --global ajv-cli ajv-formats
 
-      - name: Lint YAML
-        run: yamllint -c .yamllint.yml curricula/ concepts/ taxonomy/
+      - name: Run changed files validation
+        if: github.event_name == 'pull_request'
+        run: ./scripts/validate-changed.sh
 
-      - name: Validate syllabus files
-        run: |
-          find curricula -name "syllabus.yaml" -print0 | \
-            xargs -0 -I{} ajv validate --spec=draft2020 -s schema/syllabus.schema.json -d {}
-
-      - name: Validate subject files
-        run: |
-          find curricula -path "*/subjects/*.yaml" -print0 | \
-            xargs -0 -I{} ajv validate --spec=draft2020 -s schema/subject.schema.json -d {}
-
-      - name: Validate topic files
-        run: |
-          find curricula -path "*/topics/*" -name "*.yaml" \
-            ! -name "*.examples.yaml" ! -name "*.assessments.yaml" -print0 | \
-            xargs -0 -I{} ajv validate --spec=draft2020 -s schema/topic.schema.json -d {}
-
-      - name: Validate assessment files
-        run: |
-          find curricula -name "*.assessments.yaml" -print0 | \
-            xargs -0 -I{} ajv validate --spec=draft2020 -s schema/assessments.schema.json -d {}
-
-      - name: Validate example files
-        run: |
-          shopt -s nullglob
-          files=$(find curricula -name "*.examples.yaml")
-          if [ -n "$files" ]; then
-            echo "$files" | xargs -I{} ajv validate --spec=draft2020 -s schema/examples.schema.json -d {}
-          else
-            echo "No example files found (OK at this stage)"
-          fi
-
-      - name: Validate concept files
-        run: |
-          shopt -s nullglob
-          files=$(find concepts -name "*.yaml" 2>/dev/null)
-          if [ -n "$files" ]; then
-            echo "$files" | xargs -I{} ajv validate --spec=draft2020 -s schema/concept.schema.json -d {}
-          else
-            echo "No concept files found (OK at this stage)"
-          fi
-
-      - name: Validate taxonomy files
-        run: |
-          shopt -s nullglob
-          files=$(find taxonomy -name "*.yaml" 2>/dev/null)
-          if [ -n "$files" ]; then
-            echo "$files" | xargs -I{} ajv validate --spec=draft2020 -s schema/taxonomy.schema.json -d {}
-          else
-            echo "No taxonomy files found (OK at this stage)"
-          fi
+      - name: Run full validation
+        if: github.event_name != 'pull_request'
+        run: ./scripts/validate.sh
 ```
 
 #### 3.2 — Local Validation Script
@@ -1269,22 +1249,34 @@ fi
 chmod +x scripts/validate.sh
 ```
 
-#### 3.3 — Run Full Validation
+#### 3.3 — Changed-Files PR Validation
+
+**File:** `scripts/validate-changed.sh`
+
+```bash
+./scripts/validate-changed.sh main
+```
+
+Use this on pull requests to validate only files changed by the PR. It runs yamllint for changed curriculum YAML files and `.yamllint.yml`, validates changed curriculum YAML against the matching JSON Schema, parses changed workflow YAML, and syntax-checks validation scripts when they change.
+
+#### 3.4 — Run Full Validation
 
 ```bash
 ./scripts/validate.sh
 ```
 
-Fix any failures before proceeding.
+Run the full gate on pushes to `main`, manual workflow runs, and local release checks. Fix any failures before proceeding with a release or a full-repo validation cleanup.
 
 #### Day 3 Exit Criteria
 
 - [x] `.github/workflows/validate.yml` created
 - [x] `scripts/validate.sh` created and executable
-- [x] Full validation passes locally with zero errors
+- [x] `scripts/validate-changed.sh` created and executable
+- [x] Pull request validation checks changed files only
+- [x] Full validation remains available for `main` pushes and manual runs
 - [x] All existing content (1 syllabus, 1 subject, 3 topics, 3 assessments) validates
 
-**Progress:** 3 topics | 15 questions | 3 teaching notes | 3 assessments | 4 schemas | 1 syllabus | 1 subject | 1 CI workflow | 1 validation script
+**Progress:** 3 topics | 15 questions | 3 teaching notes | 3 assessments | 4 schemas | 1 syllabus | 1 subject | 1 CI workflow | 2 validation scripts
 
 ---
 

--- a/docs/technical-plan.md
+++ b/docs/technical-plan.md
@@ -68,19 +68,21 @@ OSS itself has no runtime dependencies. The tech stack consists entirely of data
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| **ajv-cli** | ≥5 | JSON Schema validator. Validates all YAML files against their corresponding schema on every PR. Runs in GitHub Actions CI. |
+| **uv** | current | Python tool installer/cache for CI. Installs `yamllint` and persists uv tool directories between runs. |
+| **ajv-cli** | ≥5 | JSON Schema validator. Validates changed YAML files on PRs and all YAML files on the full gate. |
 | **yamllint** | ≥1.35 | YAML syntax and style checker. Enforces consistent formatting (indentation, line length, key ordering). |
 | **Node.js** | 20 LTS | Runtime for ajv-cli. Only used in CI, not required for consuming OSS. |
-| **Python** (optional) | 3.12 | For custom validation scripts (prerequisite cycle detection, cross-reference integrity). |
+| **Ruby** | system Ruby or newer | Custom validation scripts for prerequisites, references, and quality assessment. |
+| **Python** | 3.12 | Managed by uv for Python-based tooling such as `yamllint`. |
 
 ### 2.3 CI/CD
 
 | Component | Technology | Purpose |
 |-----------|-----------|---------|
-| **CI Platform** | GitHub Actions | Free for public repositories. Runs on every push and PR. |
-| **Schema Validation** | ajv-cli | Validates every YAML file against its JSON Schema |
-| **Lint** | yamllint | Enforces YAML formatting standards |
-| **Custom Checks** | Python/Bash scripts | Prerequisite graph cycle detection, cross-reference integrity, quality level auto-assessment |
+| **CI Platform** | GitHub Actions | Pull requests run changed-file validation. Pushes to `main` and manual runs execute full validation. |
+| **Schema Validation** | ajv-cli | Validates changed YAML files on PRs and every YAML file on the full gate. |
+| **Lint** | yamllint | Enforces YAML formatting standards on changed PR files and the full repo gate. |
+| **Custom Checks** | Ruby/Bash scripts | Prerequisite graph cycle detection, cross-reference integrity, quality level auto-assessment |
 | **Release** | GitHub Releases | Tagged releases for versioned curriculum snapshots |
 
 ---
@@ -256,6 +258,7 @@ oss/
 │
 ├── scripts/                            # CI and maintenance scripts
 │   ├── validate.sh                     # Run all schema validations
+│   ├── validate-changed.sh             # Run PR validation for changed files
 │   ├── check-prerequisites.rb          # Detect cycles in prerequisite graph
 │   ├── check-references.rb             # Verify cross-references are valid
 │   ├── assess-quality.rb               # Auto-assess quality levels
@@ -264,7 +267,7 @@ oss/
 │
 ├── .github/
 │   └── workflows/
-│       ├── validate.yml                # Schema validation on every PR
+│       ├── validate.yml                # Changed-file PR validation + full main gate
 │       ├── quality-report.yml          # Quality assessment on merge to main
 │       └── release.yml                 # Tagged release with SQLite export
 │
@@ -307,69 +310,77 @@ Every topic carries a `quality_level` field (0–5) that indicates completeness.
 
 ## 6. Validation Pipeline (CI)
 
-Every PR triggers the following validation pipeline via GitHub Actions:
+Pull requests run changed-file validation so scoped fixes are not blocked by existing unrelated full-repo failures. Pushes to `main` and manual workflow runs execute the full validation gate.
 
 ```yaml
 # .github/workflows/validate.yml
 name: Validate Curriculum
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    env:
+      UV_TOOL_DIR: ${{ github.workspace }}/.ci/uv/tools
+      UV_TOOL_BIN_DIR: ${{ github.workspace }}/.ci/uv/bin
+      NPM_CONFIG_PREFIX: ${{ github.workspace }}/.ci/npm-prefix
     steps:
-      # 1. YAML syntax and style
-      - name: Lint YAML
-        run: yamllint -c .yamllint.yml curricula/ concepts/ taxonomy/
+      - uses: actions/checkout@v4
 
-      # 2. JSON Schema validation (--spec=draft2020 required for Draft 2020-12)
-      - name: Validate schemas
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          tool-dir: ${{ env.UV_TOOL_DIR }}
+          tool-bin-dir: ${{ env.UV_TOOL_BIN_DIR }}
+
+      - name: Restore validation tools
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .ci/uv/tools
+            .ci/uv/bin
+            .ci/npm-prefix
+          key: validation-tools-${{ runner.os }}-uv-yamllint-ajv-v1
+
+      - name: Install validators
         run: |
-          # Validate all syllabus files
-          find curricula -name "syllabus.yaml" | xargs -I{} \
-            ajv validate --spec=draft2020 -s schema/syllabus.schema.json -d {}
+          uv python install 3.12
+          uv tool install yamllint
+          npm install --global ajv-cli ajv-formats
 
-          # Validate all subject files
-          find curricula -path "*/subjects/*.yaml" | xargs -I{} \
-            ajv validate --spec=draft2020 -s schema/subject.schema.json -d {}
+      - name: Run changed files validation
+        if: github.event_name == 'pull_request'
+        run: ./scripts/validate-changed.sh
 
-          # Validate all topic files (exclude teaching, examples, assessments)
-          find curricula -path "*/topics/*" -name "*.yaml" \
-            ! -name "*.examples.yaml" ! -name "*.assessments.yaml" | xargs -I{} \
-            ajv validate --spec=draft2020 -s schema/topic.schema.json -d {}
-
-          # Validate examples and assessments
-          find curricula -name "*.examples.yaml" | xargs -I{} \
-            ajv validate --spec=draft2020 -s schema/examples.schema.json -d {}
-          find curricula -name "*.assessments.yaml" | xargs -I{} \
-            ajv validate --spec=draft2020 -s schema/assessments.schema.json -d {}
-
-      # 3. Prerequisite graph integrity
-      - name: Check prerequisite cycles
-        run: ruby scripts/check-prerequisites.rb
-
-      # 4. Cross-reference integrity
-      - name: Check references
-        run: ruby scripts/check-references.rb
-
-      # 5. Quality level assessment
-      - name: Assess quality levels
-        run: ruby scripts/assess-quality.rb --report
+      - name: Run full validation
+        if: github.event_name != 'pull_request'
+        run: ./scripts/validate.sh
 ```
 
 **Validation rules enforced:**
 
-| Check | Tool | Blocks Merge? |
-|-------|------|---------------|
-| YAML syntax valid | yamllint | Yes |
-| Matches JSON Schema | ajv-cli | Yes |
-| No prerequisite cycles | custom Ruby | Yes |
-| All topic_id references exist | custom Python | Yes |
-| All syllabus_id references exist | custom Python | Yes |
-| Bloom's taxonomy levels are valid | JSON Schema enum | Yes |
-| Quality level not decreased | custom Python | Warning (reviewer decides) |
-| Teaching notes file exists if referenced | custom script | Warning |
-| Translation structure matches source | custom script | Warning |
+| Check | Tool | PR Gate | Full Gate |
+|-------|------|---------|-----------|
+| Changed YAML syntax valid | yamllint | Yes | Yes |
+| Changed YAML matches JSON Schema | ajv-cli | Yes | Yes |
+| Full-repo YAML syntax valid | yamllint | No | Yes |
+| Full-repo schema validity | ajv-cli | No | Yes |
+| No prerequisite cycles | custom Ruby | No | Yes |
+| All topic_id/syllabus_id references exist | custom Ruby | No | Yes |
+| Quality level not overclaimed | custom Ruby | No | Yes |
+| Workflow YAML parses | Ruby YAML parser | Yes, when workflow changes | Yes, through workflow execution |
 
 ---
 

--- a/scripts/validate-changed.sh
+++ b/scripts/validate-changed.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${1:-${GITHUB_BASE_REF:-main}}"
+ERRORS=0
+
+echo "=== OSS Changed Files Validation ==="
+
+if git rev-parse --verify --quiet "origin/${BASE_REF}" >/dev/null; then
+  BASE_COMMIT="origin/${BASE_REF}"
+elif git rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+  BASE_COMMIT="${BASE_REF}"
+else
+  echo "Fetching base ref: ${BASE_REF}"
+  git fetch --no-tags --depth=1 origin "${BASE_REF}"
+  BASE_COMMIT="origin/${BASE_REF}"
+fi
+
+mapfile -t CHANGED_FILES < <(
+  {
+    git diff --name-only --diff-filter=ACMR "${BASE_COMMIT}...HEAD"
+    git diff --name-only --diff-filter=ACMR
+    git diff --name-only --cached --diff-filter=ACMR
+    git ls-files --others --exclude-standard
+  } |
+    awk '
+      /^(curricula|concepts|taxonomy)\// && /\.ya?ml$/ { print }
+      /^\.github\/workflows\/.*\.ya?ml$/ { print }
+      /^schema\/.*\.schema\.json$/ { print }
+      /^scripts\/validate/ { print }
+      /^\.yamllint\.yml$/ { print }
+    ' |
+    sort -u
+)
+
+if [ "${#CHANGED_FILES[@]}" -eq 0 ]; then
+  echo "SKIP: No changed validation-relevant files"
+  exit 0
+fi
+
+printf "Changed validation-relevant files:\n"
+printf -- "- %s\n" "${CHANGED_FILES[@]}"
+
+mapfile -t YAML_FILES < <(printf "%s\n" "${CHANGED_FILES[@]}" | awk '/^(curricula|concepts|taxonomy)\/.*\.ya?ml$/')
+mapfile -t YAMLLINT_FILES < <(
+  printf "%s\n" "${CHANGED_FILES[@]}" |
+    awk '/^(curricula|concepts|taxonomy)\/.*\.ya?ml$/ || /^\.yamllint\.yml$/'
+)
+mapfile -t WORKFLOW_FILES < <(printf "%s\n" "${CHANGED_FILES[@]}" | awk '/^\.github\/workflows\/.*\.ya?ml$/')
+
+if [ "${#YAMLLINT_FILES[@]}" -gt 0 ]; then
+  if yamllint -c .yamllint.yml "${YAMLLINT_FILES[@]}"; then
+    echo "PASS: YAML lint for changed files"
+  else
+    echo "FAIL: YAML lint for changed files"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  echo "SKIP: No changed yamllint-covered files"
+fi
+
+if [ "${#WORKFLOW_FILES[@]}" -gt 0 ]; then
+  ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file) }' "${WORKFLOW_FILES[@]}"
+  echo "PASS: workflow YAML parses"
+fi
+
+schema_for_file() {
+  local file="$1"
+
+  case "$file" in
+    concepts/*.yaml)
+      echo "schema/concept.schema.json"
+      ;;
+    taxonomy/*.yaml)
+      echo "schema/taxonomy.schema.json"
+      ;;
+    curricula/*/syllabus.yaml)
+      echo "schema/syllabus.schema.json"
+      ;;
+    curricula/*/subjects/*.yaml)
+      echo "schema/subject.schema.json"
+      ;;
+    curricula/*.assessments.yaml|curricula/**/*.assessments.yaml)
+      echo "schema/assessments.schema.json"
+      ;;
+    curricula/*.examples.yaml|curricula/**/*.examples.yaml)
+      echo "schema/examples.schema.json"
+      ;;
+    curricula/*/topics/*.yaml|curricula/**/topics/*.yaml)
+      echo "schema/topic.schema.json"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+SCHEMA_FILES_CHANGED=false
+for file in "${CHANGED_FILES[@]}"; do
+  if [[ "$file" == schema/*.schema.json ]]; then
+    SCHEMA_FILES_CHANGED=true
+    break
+  fi
+done
+
+if [ "$SCHEMA_FILES_CHANGED" = true ]; then
+  echo "FAIL: Schema files changed; run full validation on this PR"
+  echo "Changed schema files can affect untouched curriculum files."
+  ERRORS=$((ERRORS + 1))
+elif [ "${#YAML_FILES[@]}" -gt 0 ]; then
+  schema_count=0
+  schema_fails=0
+
+  for file in "${YAML_FILES[@]}"; do
+    if schema="$(schema_for_file "$file")"; then
+      schema_count=$((schema_count + 1))
+      if ajv validate --spec=draft2020 -s "$schema" -d "$file" >/dev/null; then
+        echo "PASS: $file"
+      else
+        echo "FAIL: $file"
+        ajv validate --spec=draft2020 -s "$schema" -d "$file" || true
+        schema_fails=$((schema_fails + 1))
+      fi
+    else
+      echo "SKIP: No schema mapping for $file"
+    fi
+  done
+
+  if [ "$schema_fails" -eq 0 ]; then
+    echo "PASS: $schema_count changed schema-validatable file(s)"
+  else
+    echo "FAIL: $schema_fails/$schema_count changed schema-validatable file(s)"
+    ERRORS=$((ERRORS + schema_fails))
+  fi
+else
+  echo "SKIP: No changed YAML files for schema validation"
+fi
+
+if printf "%s\n" "${CHANGED_FILES[@]}" | grep -Eq '^scripts/validate'; then
+  bash -n scripts/validate.sh
+  bash -n scripts/validate-changed.sh
+  echo "PASS: validation scripts parse"
+fi
+
+if [ "$ERRORS" -eq 0 ]; then
+  echo "PASS: Changed files validation passed"
+  exit 0
+fi
+
+echo "FAIL: $ERRORS changed-files validation error(s) found"
+exit 1


### PR DESCRIPTION
## What changed

- Added `scripts/validate-changed.sh` for pull requests.
- Updated the validation workflow so pull requests validate only changed validation-relevant files.
- Kept the full `./scripts/validate.sh` gate for `main` pushes and manual workflow runs.
- Switched validator setup to use uv for Python tooling and cached tool directories for faster repeat runs.

## Why

`main` currently has existing full-repo validation failures, so running the full gate on every PR blocks scoped cleanup PRs even when their touched files are valid. This keeps the full gate honest while letting PRs prove they do not worsen changed files.

## Impact

Pull requests now run yamllint and matching schema validation for changed curriculum YAML files, parse workflow YAML when workflows change, and syntax-check validation scripts when validation scripts change. Branch pushes no longer run the full validation workflow unless they target `main`.

## Validation

- `./scripts/validate-changed.sh github/main`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/validate.yml")'`
- `bash -n scripts/validate-changed.sh && bash -n scripts/validate.sh`

Note: full `./scripts/validate.sh` remains red on current `main` due existing repo-wide validation failures.
